### PR TITLE
Support multiple proxies, and use a safer api to load the twemproxy yaml.

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -98,7 +98,7 @@ Agent.prototype.switch_master_handler = function(){
 Agent.prototype.load_twemproxy_config = function(callback){
   this.log("Loading TwemProxy config");
   try {
-    this.doc = require(this.nutcracker_config_file);
+    this.doc = yaml.safeLoad(fs.readFileSync(this.nutcracker_config_file, 'utf8'));
     return callback();
   } catch (e) {
     return callback("Failed to load " + this.nutcracker_config_file);

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -22,18 +22,18 @@ function Agent(config){
   this.log_file		      = config.log_file;
 }
 
-// Logs a message to the console and to the file 
+// Logs a message to the console and to the file
 // specifid in the cli.js
 Agent.prototype.log = function (message) {
   var theDate = new Date(),
-      hour = theDate.getHours().toString(), 
-      min = theDate.getMinutes().toString(), 
+      hour = theDate.getHours().toString(),
+      min = theDate.getMinutes().toString(),
       sec = theDate.getSeconds().toString();
 
   hour = (hour.length != 1) ? hour : "0" + hour;
   min  = (min.length != 1) ? min : "0" + min;
   sec  = (sec.length != 1) ? sec : "0" + sec;
-  
+
   var theMessage = "[" + hour + ":" + min + ":" + sec + "] " + message;
   util.puts(theMessage);
 
@@ -66,12 +66,12 @@ Agent.prototype.update_master_address = function(server, address) {
   this.log("Updating Master " + server + " to " + address);
   var found = false;
   _.each(this.doc, function(proxy_data, proxy_name) {
-    _.each(proxy_data.servers, function(server_entry) {
+    _.each(proxy_data.servers, function(server_entry, server_idx) {
       // we need to get the server name from the config value
       var conf_name = _.last(server_entry.split(' '));
       if(conf_name == server) {
         // We've found the matching server
-        server_entry = address + ":1 " + server;
+        proxy_data.servers[server_idx] = address + ":1 " + server;
         found = true;
       };
     });
@@ -102,18 +102,16 @@ Agent.prototype.load_twemproxy_config = function(callback){
   this.log("Loading TwemProxy config");
   try {
     this.doc = yaml.safeLoad(fs.readFileSync(this.nutcracker_config_file, 'utf8'));
-    return callback();
+    callback();
   } catch (e) {
-    return callback("Failed to load " + this.nutcracker_config_file);
-  };
-
+    return callback(e);
+  }
 };
 
 // Saves the TwemProxy config file to disk
 Agent.prototype.save_twemproxy_config = function(callback){
   this.log("Saving TwemProxy config");
-  fs.writeFileSync(this.nutcracker_config_file, yaml.safeDump(this.doc), 'utf8');
-  return callback();
+  fs.writeFile(this.nutcracker_config_file, yaml.safeDump(this.doc), callback);
 };
 
 // This will connect to Redis Sentinel and get a list of all current
@@ -122,7 +120,7 @@ Agent.prototype.force_master_update = function() {
   var self = this;
   var client2 = redis.createClient(
     self.redis_sentinel_port,
-    self.redis_sentinel_ip, 
+    self.redis_sentinel_ip,
     {
       retry_max_delay: 5000
     }
@@ -131,7 +129,7 @@ Agent.prototype.force_master_update = function() {
 
   // Get the masters list
   client2.send_command("SENTINEL", ["masters"], function (err, reply) {
-    
+
     for (var i = 0; i < reply.length; i++) {
       var server = reply[i][1];
       var address = reply[i][3] + ":" + reply[i][5];
@@ -154,13 +152,13 @@ Agent.prototype.force_master_update = function() {
 
 // Starts the pub/sub monitor on Sentinel
 Agent.prototype.start_sentinel = function(){
-  
+
   this.log("Redis Sentinel TwemProxy Agent Started on: " + (new Date()).toString());
   var handler = this.switch_master_handler();
   var self = this;
   this.client = redis.createClient(
       this.redis_sentinel_port,
-      this.redis_sentinel_ip, 
+      this.redis_sentinel_ip,
       {
  	      retry_max_delay: 5000
       }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -64,18 +64,21 @@ Agent.prototype.restart_twemproxy = function(callback){
 // Updates the address of a server, by its name, in the TwemProxy config
 Agent.prototype.update_master_address = function(server, address) {
   this.log("Updating Master " + server + " to " + address);
-  for (var s = 0; s < this.doc.twem1.servers.length; s++) {
-    // we need to get the server name from the config value
-    var confServerSplit = this.doc.twem1.servers[s].split(' ');
-    var confServer = confServerSplit[confServerSplit.length-1];
-
-    if(confServer == server) {
-      // We've found the matching server
-      this.doc.twem1.servers[s] = address + ":1 " + server;
-      return;
-    };
-  };
-  this.log("WARNING: Update Failed! Server " + server + " not found in TwemProxy config!");
+  var found = false;
+  _.each(this.doc, function(proxy_data, proxy_name) {
+    _.each(proxy_data.servers, function(server_entry) {
+      // we need to get the server name from the config value
+      var conf_name = _.last(server_entry.split(' '));
+      if(conf_name == server) {
+        // We've found the matching server
+        server_entry = address + ":1 " + server;
+        found = true;
+      };
+    });
+  });
+  if (!found) {
+    this.log("WARNING: Update Failed! Server " + server + " not found in TwemProxy config!");
+  }
 };
 
 // The handler for the master-switch event from Redis Sentinel


### PR DESCRIPTION
This removes the restriction that there is only one proxy in the twemproxy config, and that the element needs to be called twem1.
